### PR TITLE
Refactor: use events to prevent globals

### DIFF
--- a/clients.js
+++ b/clients.js
@@ -77,38 +77,27 @@ function clients () {
 
     function encryptOptionTo (recipient) {
       var peer = getPeerAc(recipient)
-      var toggle = {
-        visible: true,
-        enabled: true,
-        preferred: false,
-        explanation: ''
-      }
-      if (!isEnabled()) {
-        if (peer.preferEncrypted) {
-          toggle.explanation = 'enable Autocrypt to encrypt'
-        }
-        else {
-          toggle.visible = false
-          toggle.enabled = false
-        }
-      }
-      else {
-        if (peer.key) {
-          toggle.preferred = peer.preferEncrypted
-        }
-        else {
-          toggle.enabled = false
+      function explanation() {
+        if (isEnabled()) {
+          if (peer.key) { return }
           if (recipient === '') {
-            toggle.explanation = 'please choose a recipient'
+            return 'please choose a recipient'
           }
-          else {
-            toggle.explanation = 'If you want to encrypt to ' + recipient +
-              ', ask ' + recipient +
-              ' to enable Autocrypt and send you an e-mail'
-          }
+          return 'If you want to encrypt to ' + recipient +
+            ', ask ' + recipient +
+            ' to enable Autocrypt and send you an e-mail'
+        }
+        if (peer.preferEncrypted) {
+          return 'enable Autocrypt to encrypt'
         }
       }
-      return toggle
+
+      return {
+        visible: isEnabled() || peer.preferEncrypted,
+        enabled: (isEnabled() && peer.key) || (peer.key && peer.preferEncrypted),
+        preferred: isEnabled() && peer.key && peer.preferEncrypted,
+        explanation: explanation() || ''
+      }
     }
 
     return {

--- a/clients.js
+++ b/clients.js
@@ -75,6 +75,42 @@ function clients () {
       return autocrypt.enabled
     }
 
+    function encryptOptionTo (recipient) {
+      var peer = getPeerAc(recipient)
+      var toggle = {
+        visible: true,
+        enabled: true,
+        preferred: false,
+        explanation: ''
+      }
+      if (!isEnabled()) {
+        if (peer.preferEncrypted) {
+          toggle.explanation = 'enable Autocrypt to encrypt'
+        }
+        else {
+          toggle.visible = false
+          toggle.enabled = false
+        }
+      }
+      else {
+        if (peer.key) {
+          toggle.preferred = peer.preferEncrypted
+        }
+        else {
+          toggle.enabled = false
+          if (recipient === '') {
+            toggle.explanation = 'please choose a recipient'
+          }
+          else {
+            toggle.explanation = 'If you want to encrypt to ' + recipient +
+              ', ask ' + recipient +
+              ' to enable Autocrypt and send you an e-mail'
+          }
+        }
+      }
+      return toggle
+    }
+
     return {
       autocrypt: autocrypt,
       processIncoming: processIncoming,
@@ -82,7 +118,8 @@ function clients () {
       getPeerAc: getPeerAc,
       enable: enable,
       isEnabled: isEnabled,
-      selfSyncAutocryptState: selfSyncAutocryptState
+      selfSyncAutocryptState: selfSyncAutocryptState,
+      encryptOptionTo: encryptOptionTo
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
         <script type="text/javascript" src="ui.js"></script>
         <script type="text/javascript" src="ui/panes.js"></script>
         <script type="text/javascript" src="ui/compose.js"></script>
+        <script type="text/javascript" src="ui/view.js"></script>
         <script type="text/javascript" src="clients.js"></script>
         <script type="text/javascript" src="autocrypt.js"></script>
         <script type="text/javascript" src="tests.js"></script>
@@ -59,7 +60,7 @@
             </table>
         </div>
 
-        <div id="msgView">
+        <div id="view">
                 <table><tbody>
                         <tr><th>From:</th><td id="viewFrom"></td></tr>
                         <tr><th>To:</th><td id="viewTo"></td></tr>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                         <tr><th>Subject:</th><td><input id="subject" /></td></tr>
                         <tr id="encryptedRow"><td colspan="2"><label><input type="checkbox" onclick="return ui.clickencrypted();" id="encrypted">Encrypt</label><span id="explanation"></span></td></tr>
                         <tr><td id="compose-actions" colspan="2">
-                                <input type="button" id="send" onclick="return ui.sendmail();" value="Send"/>
+                                <input type="button" id="send" value="Send"/>
                         </td></tr>
                         <tr><td colspan="2">
                                 <textarea id="body"></textarea>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
         <script type="text/javascript" src="ui.js"></script>
         <script type="text/javascript" src="ui/panes.js"></script>
         <script type="text/javascript" src="ui/compose.js"></script>
+        <script type="text/javascript" src="ui/list.js"></script>
         <script type="text/javascript" src="ui/view.js"></script>
         <script type="text/javascript" src="clients.js"></script>
         <script type="text/javascript" src="autocrypt.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,9 @@
         <title>Autocrypt Essential UI Demo</title>
         <script type="text/javascript" src="providers/volatileProvider.js"></script>
         <script type="text/javascript" src="users.js"></script>
-        <script type="text/javascript" src="ui/panes.js"></script>
         <script type="text/javascript" src="ui.js"></script>
+        <script type="text/javascript" src="ui/panes.js"></script>
+        <script type="text/javascript" src="ui/compose.js"></script>
         <script type="text/javascript" src="clients.js"></script>
         <script type="text/javascript" src="autocrypt.js"></script>
         <script type="text/javascript" src="tests.js"></script>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             <div>
                 <table><tbody>
                         <tr><th>From:</th><td id="from"></td></tr>
-                        <tr><th>To:</th><td><input onchange="return ui.updatecompose();" id="to" /></td></tr>
+                        <tr><th>To:</th><td><input id="to" /></td></tr>
                         <tr><th>Subject:</th><td><input id="subject" /></td></tr>
                         <tr id="encryptedRow"><td colspan="2"><label><input type="checkbox" onclick="return ui.clickencrypted();" id="encrypted">Encrypt</label><span id="explanation"></span></td></tr>
                         <tr><td id="compose-actions" colspan="2">

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -14,7 +14,7 @@
   function composeTo (recipient) {
     click('tab-compose')
     document.getElementById('to').value = recipient
-    document.getElementById('to').onchange()
+    document.getElementById('to').dispatchEvent(new Event('change'))
     document.getElementById('subject').value = 'subject'
     document.getElementById('body').value = 'body'
   }

--- a/ui.js
+++ b/ui.js
@@ -17,9 +17,8 @@ function userInterface () {
   function setup (event) {
     dom = getElements('more', 'listReplacement', 'msgtable',
         'username', 'from', 'to', 'subject', 'body', 'msglist',
-        'viewFrom', 'viewTo', 'viewSubject', 'viewDate', 'viewBody', 'viewEncrypted',
         'encrypted', 'encryptedRow', 'showmore', 'reply', 'yes', 'no', 'enable',
-        'compose', 'list', 'msgView', 'preferences',
+        'compose', 'list', 'view', 'preferences',
         'description', 'explanation', 'settings')
 
     dom.encrypted.parentNode.insertBefore(img('lock'), dom.encrypted)
@@ -39,22 +38,12 @@ function userInterface () {
   }
 
   function showMsg (msg) {
-    dom.viewFrom.innerText = msg['from']
-    dom.viewTo.innerText = msg['to']
-    dom.viewSubject.innerText = msg['subject']
-    dom.viewDate.innerText = msg['date']
-    dom.viewEncrypted.replaceChild(getEncryptionStatusNode(msg.encrypted), dom.viewEncrypted.childNodes[0])
-    dom.viewBody.innerText = msg['body']
-    // fix before refactor
-    var usr = us.current()
-    if (msg.from === usr.name) {
-      dom.reply.style.display = 'none'
-    } else {
-      dom.reply.style.display = 'inline'
-      dom.reply.onclick = function () { replyToMsg(msg) }
-    }
-
-    dom.msgView.dispatchEvent(select)
+    var show = new CustomEvent('show', {
+      detail: {message: msg}
+    })
+    dom.view.dispatchEvent(show)
+    dom.reply.onclick = function () { replyToMsg(msg) }
+    dom.view.dispatchEvent(select)
   }
 
   function replyToMsg (msg) {
@@ -223,20 +212,6 @@ function userInterface () {
       dom.yes.checked = false
       dom.no.checked = true
     }
-  }
-
-  function getEncryptionStatusNode (encrypted) {
-    var x = document.createElement('span')
-    if (encrypted) {
-      var sub = document.createElement('span')
-      x.appendChild(img('lock'))
-      sub.innerText = 'Message was encrypted'
-      x.appendChild(sub)
-    } else {
-      x.innerText = 'Message was not encrypted'
-    }
-
-    return x
   }
 
   function generateListEntryFromMsg (msg) {

--- a/ui.js
+++ b/ui.js
@@ -43,6 +43,8 @@ function userInterface () {
       dom.compose.dispatchEvent(select)
     })
 
+    dom.compose.addEventListener("send", sendmail)
+
     changeUser('Alice')
     updateDescription()
   }
@@ -70,8 +72,8 @@ function userInterface () {
     }
   }
 
-  function sendmail () {
-    addmail(dom.to.value, dom.subject.value, dom.body.value, dom.encrypted.checked)
+  function sendmail (e) {
+    addmail(e.detail.to, e.detail.subject, e.detail.body, e.detail.encrypted)
     dom.list.dispatchEvent(select)
   }
 
@@ -254,15 +256,13 @@ function userInterface () {
   document.addEventListener("DOMContentLoaded", setup)
 
   return {
-    setup: setup,
     updateDescription: updateDescription,
     switchuser: switchuser,
     updatecompose: updatecompose,
     autocryptEnable: autocryptEnable,
     autocryptPreference: autocryptPreference,
     clickencrypted: clickencrypted,
-    more: more,
-    sendmail: sendmail
+    more: more
   }
 }
 

--- a/ui.js
+++ b/ui.js
@@ -71,13 +71,8 @@ function userInterface () {
   }
 
   function sendmail () {
-    if (addmail(dom.to.value, dom.subject.value, dom.body.value, dom.encrypted.checked)) {
-      clearcompose()
-      dom.list.dispatchEvent(select)
-      return false
-    } else {
-      return false
-    }
+    addmail(dom.to.value, dom.subject.value, dom.body.value, dom.encrypted.checked)
+    dom.list.dispatchEvent(select)
   }
 
   function clearcompose () {

--- a/ui.js
+++ b/ui.js
@@ -33,6 +33,16 @@ function userInterface () {
       clearcompose()
     })
 
+    dom.view.addEventListener("reply", function (e) {
+      // just reusing the event triggers an InvalidStateError.
+      // so let's have a new one...
+      var reply = new CustomEvent('reply', {
+        detail: e.detail
+      })
+      dom.compose.dispatchEvent(reply)
+      dom.compose.dispatchEvent(select)
+    })
+
     changeUser('Alice')
     updateDescription()
   }
@@ -42,20 +52,7 @@ function userInterface () {
       detail: {message: msg}
     })
     dom.view.dispatchEvent(show)
-    dom.reply.onclick = function () { replyToMsg(msg) }
     dom.view.dispatchEvent(select)
-  }
-
-  function replyToMsg (msg) {
-    function indent (str) {
-      return str.split('\n').map(function (y) { return '> ' + y }).join('\n')
-    }
-
-    dom.to.value = msg.from
-    dom.subject.value = 'Re: ' + msg.subject
-    dom.body.value = indent(msg.body)
-    dom.compose.dispatchEvent(select)
-    dom.encrypted.checked = dom.encrypted.checked || msg.encrypted
   }
 
   function populateList () {

--- a/ui.js
+++ b/ui.js
@@ -15,18 +15,16 @@ function userInterface () {
 
   // run when the dom is loaded
   function setup (event) {
-    dom = getElements('more', 'listReplacement', 'msgtable',
-        'username', 'from', 'to', 'subject', 'body', 'msglist',
+    dom = getElements('more', 'username', 'from', 'to',
         'encrypted', 'encryptedRow', 'showmore', 'reply', 'yes', 'no', 'enable',
         'compose', 'list', 'view', 'preferences',
         'description', 'explanation', 'settings')
 
-    dom.encrypted.parentNode.insertBefore(img('lock'), dom.encrypted)
-
     dom.list.addEventListener("selected", function (e) {
+      clearCompose()
       populateList()
-      clearcompose()
     })
+    dom.list.addEventListener("showMessage", showMessage)
 
     dom.view.addEventListener("reply", function (e) {
       // just reusing the event triggers an InvalidStateError.
@@ -45,27 +43,19 @@ function userInterface () {
     updateDescription()
   }
 
-  function showMsg (msg) {
+  function showMessage (e) {
     var show = new CustomEvent('show', {
-      detail: {message: msg}
+      detail: e.detail
     })
     dom.view.dispatchEvent(show)
     dom.view.dispatchEvent(select)
   }
 
   function populateList () {
-    while (dom.msglist.hasChildNodes()) { dom.msglist.removeChild(dom.msglist.lastChild) }
-
-    if (messages.length) {
-      for (var x in messages) {
-        dom.msglist.appendChild(generateListEntryFromMsg(messages[x]))
-      }
-      dom.listReplacement.style.display = 'none'
-      dom.msgtable.style.display = 'table'
-    } else {
-      dom.listReplacement.style.display = 'block'
-      dom.msgtable.style.display = 'none'
-    }
+    var populate = new CustomEvent('populate', {
+      detail: {messages: messages}
+    })
+    dom.list.dispatchEvent(populate)
   }
 
   function sendmail (e) {
@@ -73,7 +63,7 @@ function userInterface () {
     dom.list.dispatchEvent(select)
   }
 
-  function clearcompose () {
+  function clearCompose () {
     dom.compose.dispatchEvent(new Event('clear'))
   }
 
@@ -204,51 +194,6 @@ function userInterface () {
       dom.yes.checked = false
       dom.no.checked = true
     }
-  }
-
-  function generateListEntryFromMsg (msg) {
-    var ret = document.createElement('tr')
-    ret.classList.add('message')
-    ret.onclick = function () { showMsg(msg) }
-
-    var e = document.createElement('td')
-    if (msg['encrypted']) { e.appendChild(img('lock')) }
-    if (msg['to'].toLowerCase() === dom.username.innerText.toLowerCase()) {
-      e.appendChild(img('back'))
-    }
-    if (msg['from'].toLowerCase() === dom.username.innerText.toLowerCase()) {
-      e.appendChild(img('forward'))
-    }
-    ret.appendChild(e)
-
-    var f = document.createElement('td')
-    f.innerText = msg['from']
-    ret.appendChild(f)
-
-    var t = document.createElement('td')
-    t.innerText = msg['to']
-    ret.appendChild(t)
-
-    var s = document.createElement('td')
-    s.innerText = msg['subject']
-    ret.appendChild(s)
-
-    var d = document.createElement('td')
-    d.innerText = msg['date']
-    ret.appendChild(d)
-
-    return ret
-  }
-
-  function img (what) {
-    var index = {
-      lock: 'assets/images/emblem-readonly.png',
-      back: 'assets/images/back.png',
-      forward: 'assets/images/forward.png'
-    }
-    var lock = document.createElement('img')
-    lock.src = index[what]
-    return lock
   }
 
   document.addEventListener("DOMContentLoaded", setup)

--- a/ui.js
+++ b/ui.js
@@ -38,13 +38,6 @@ function userInterface () {
     updateDescription()
   }
 
-  function clearcompose () {
-    dom.to.value = ''
-    dom.body.value = ''
-    dom.subject.value = ''
-    dom.encrypted.checked = false
-  }
-
   function showMsg (msg) {
     dom.viewFrom.innerText = msg['from']
     dom.viewTo.innerText = msg['to']
@@ -101,31 +94,15 @@ function userInterface () {
     }
   }
 
-  function updatecompose () {
-    var to = dom.to.value
-    var ac = client.getPeerAc(to)
+  function clearcompose () {
+    dom.compose.dispatchEvent(new Event('clear'))
+  }
 
-    if (!client.isEnabled()) {
-      if (ac.preferEncrypted) {
-        dom.encryptedRow.style.display = 'table-row'
-        dom.encrypted.checked = false
-        enablecheckbox(dom.encrypted, true)
-        dom.explanation.innerText = 'enable Autocrypt to encrypt'
-      } else {
-        dom.encryptedRow.style.display = 'none'
-      }
-    } else {
-      dom.encryptedRow.style.display = 'table-row'
-      if (ac.key !== undefined) {
-        dom.encrypted.checked = ac.preferEncrypted
-        enablecheckbox(dom.encrypted, true)
-        dom.explanation.innerText = ''
-      } else {
-        dom.encrypted.checked = false
-        enablecheckbox(dom.encrypted, false)
-        if (to === '') { dom.explanation.innerText = 'please choose a recipient' } else { dom.explanation.innerText = 'If you want to encrypt to ' + to + ', ask ' + to + ' to enable Autocrypt and send you an e-mail' }
-      }
-    }
+  function updatecompose () {
+    var e = new CustomEvent('update', {
+      detail: { client: client }
+    })
+    dom.compose.dispatchEvent(e)
   }
 
   function clickencrypted () {
@@ -199,11 +176,6 @@ function userInterface () {
   function autocryptEnable () {
     client.enable(dom.enable.checked)
     updateDescription()
-  }
-
-  function enablecheckbox (box, enabled) {
-    box.disabled = !enabled
-    if (enabled) { box.parentElement.classList.remove('disabled') } else { box.parentElement.classList.add('disabled') }
   }
 
   function updateDescription () {

--- a/ui.js
+++ b/ui.js
@@ -23,12 +23,7 @@ function userInterface () {
 
     dom.encrypted.parentNode.insertBefore(img('lock'), dom.encrypted)
 
-
-    document.getElementById('tab-compose').addEventListener("selected", function (e) {
-      dom.to.focus()
-      updatecompose()
-    })
-    document.getElementById('tab-list').addEventListener("selected", function (e) {
+    dom.list.addEventListener("selected", function (e) {
       populateList()
       clearcompose()
     })
@@ -43,6 +38,7 @@ function userInterface () {
       dom.compose.dispatchEvent(select)
     })
 
+    dom.compose.addEventListener("toChanged", updateCompose)
     dom.compose.addEventListener("send", sendmail)
 
     changeUser('Alice')
@@ -81,11 +77,14 @@ function userInterface () {
     dom.compose.dispatchEvent(new Event('clear'))
   }
 
-  function updatecompose () {
-    var e = new CustomEvent('update', {
-      detail: { client: client }
+  function updateCompose (e) {
+    var update = new CustomEvent('update', {
+      detail: {
+        client: client,
+        peer: client.getPeerAc(e.detail.to)
+      }
     })
-    dom.compose.dispatchEvent(e)
+    dom.compose.dispatchEvent(update)
   }
 
   function clickencrypted () {
@@ -258,7 +257,6 @@ function userInterface () {
   return {
     updateDescription: updateDescription,
     switchuser: switchuser,
-    updatecompose: updatecompose,
     autocryptEnable: autocryptEnable,
     autocryptPreference: autocryptPreference,
     clickencrypted: clickencrypted,

--- a/ui.js
+++ b/ui.js
@@ -80,8 +80,7 @@ function userInterface () {
   function updateCompose (e) {
     var update = new CustomEvent('update', {
       detail: {
-        client: client,
-        peer: client.getPeerAc(e.detail.to)
+        toggle: client.encryptOptionTo(e.detail.to)
       }
     })
     dom.compose.dispatchEvent(update)

--- a/ui.js
+++ b/ui.js
@@ -3,7 +3,7 @@ console.log('ui v0.0.6')
 
 function userInterface () {
   var dom = {}
-  var panes = uiPanes()
+  var select = new Event('select')
 
   function getElements() {
     collection = {}
@@ -19,11 +19,11 @@ function userInterface () {
         'username', 'from', 'to', 'subject', 'body', 'msglist',
         'viewFrom', 'viewTo', 'viewSubject', 'viewDate', 'viewBody', 'viewEncrypted',
         'encrypted', 'encryptedRow', 'showmore', 'reply', 'yes', 'no', 'enable',
+        'compose', 'list', 'msgView', 'preferences',
         'description', 'explanation', 'settings')
 
     dom.encrypted.parentNode.insertBefore(img('lock'), dom.encrypted)
 
-    panes.setup()
 
     document.getElementById('tab-compose').addEventListener("selected", function (e) {
       dom.to.focus()
@@ -35,7 +35,6 @@ function userInterface () {
     })
 
     changeUser('Alice')
-    panes.select('list')
     updateDescription()
   }
 
@@ -62,7 +61,7 @@ function userInterface () {
       dom.reply.onclick = function () { replyToMsg(msg) }
     }
 
-    panes.select('msgView')
+    dom.msgView.dispatchEvent(select)
   }
 
   function replyToMsg (msg) {
@@ -73,7 +72,7 @@ function userInterface () {
     dom.to.value = msg.from
     dom.subject.value = 'Re: ' + msg.subject
     dom.body.value = indent(msg.body)
-    panes.select('compose')
+    dom.compose.dispatchEvent(select)
     dom.encrypted.checked = dom.encrypted.checked || msg.encrypted
   }
 
@@ -95,7 +94,7 @@ function userInterface () {
   function sendmail () {
     if (addmail(dom.to.value, dom.subject.value, dom.body.value, dom.encrypted.checked)) {
       clearcompose()
-      panes.select('list')
+      dom.list.dispatchEvent(select)
       return false
     } else {
       return false
@@ -236,7 +235,7 @@ function userInterface () {
     dom.from.innerText = user.name
     setupprefs()
     dom.showmore.checked = false
-    panes.select('list')
+    dom.list.dispatchEvent(select)
     updateDescription()
   }
 

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -11,6 +11,7 @@
     if (pane) {
       pane.addEventListener('clear', clear, false)
       pane.addEventListener('update', update, false)
+      pane.addEventListener('reply', reply, false)
     }
   }
 
@@ -34,11 +35,12 @@
         dom.explanation.innerText = 'enable Autocrypt to encrypt'
       } else {
         dom.encryptedRow.style.display = 'none'
+        dom.encrypted.checked = false
       }
     } else {
       dom.encryptedRow.style.display = 'table-row'
       if (ac.key !== undefined) {
-        dom.encrypted.checked = ac.preferEncrypted
+        dom.encrypted.checked = dom.encrypted.checked || ac.preferEncrypted
         enablecheckbox(dom.encrypted, true)
         dom.explanation.innerText = ''
       } else {
@@ -47,6 +49,19 @@
         if (to === '') { dom.explanation.innerText = 'please choose a recipient' } else { dom.explanation.innerText = 'If you want to encrypt to ' + to + ', ask ' + to + ' to enable Autocrypt and send you an e-mail' }
       }
     }
+  }
+
+  function reply(e){
+    var msg = e.detail.message
+
+    function indent (str) {
+      return str.split('\n').map(function (y) { return '> ' + y }).join('\n')
+    }
+
+    dom.to.value = msg.from
+    dom.subject.value = 'Re: ' + msg.subject
+    dom.body.value = indent(msg.body)
+    dom.encrypted.checked = dom.encrypted.checked || msg.encrypted
   }
 
   function getElements() {

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -27,7 +27,6 @@
     // On replies this may already be checked. So do not uncheck.
     dom.encrypted.checked = dom.encrypted.checked || toggle.preferred
     dom.explanation.innerText = toggle.explanation
-
   }
 
   function reply(e){

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -10,16 +10,17 @@
   }
 
   function update (e) {
-    var client = e.detail.client
     var to = dom.to.value
-    var ac = client.getPeerAc(to)
+    var client = e.detail.client
+    var peer = e.detail.peer
+
     function enablecheckbox (box, enabled) {
       box.disabled = !enabled
         if (enabled) { box.parentElement.classList.remove('disabled') } else { box.parentElement.classList.add('disabled') }
     }
 
     if (!client.isEnabled()) {
-      if (ac.preferEncrypted) {
+      if (peer.preferEncrypted) {
         dom.encryptedRow.style.display = 'table-row'
         dom.encrypted.checked = false
         enablecheckbox(dom.encrypted, true)
@@ -30,8 +31,8 @@
       }
     } else {
       dom.encryptedRow.style.display = 'table-row'
-      if (ac.key !== undefined) {
-        dom.encrypted.checked = dom.encrypted.checked || ac.preferEncrypted
+      if (peer.key !== undefined) {
+        dom.encrypted.checked = dom.encrypted.checked || peer.preferEncrypted
         enablecheckbox(dom.encrypted, true)
         dom.explanation.innerText = ''
       } else {
@@ -56,13 +57,21 @@
   }
 
   function send (){
-    var sendEvent = new CustomEvent('send', { detail: {
+    emit('send', {
       to: dom.to.value,
       subject: dom.subject.value,
       body: dom.body.value,
       encrypted: dom.encrypted.checked
-    }})
-    pane.dispatchEvent(sendEvent)
+    })
+  }
+
+  function toChanged (){
+    emit('toChanged', { to: dom.to.value })
+  }
+
+  function emit(name, detail){
+    var emitEvent = new CustomEvent(name, { detail: detail } )
+    pane.dispatchEvent(emitEvent)
   }
 
   function getElements() {
@@ -84,9 +93,12 @@
       pane.addEventListener('clear', clear, false)
       pane.addEventListener('update', update, false)
       pane.addEventListener('reply', reply, false)
+      pane.addEventListener("selected", dom.to.focus, false)
+      pane.addEventListener("selected", toChanged, false)
     }
 
     dom.send.addEventListener('click', send, false)
+    dom.to.addEventListener('change', toChanged, false)
   }
 
   document.addEventListener("DOMContentLoaded", setup)

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -13,7 +13,12 @@
     var to = dom.to.value
     var client = e.detail.client
     var peer = e.detail.peer
-    var toggle = {}
+    var toggle = {
+      visible: true,
+      enabled: true,
+      preferred: false,
+      explanation: ''
+    }
 
     function enableCheckbox (enabled) {
       var box = dom.encrypted
@@ -27,28 +32,19 @@
 
     if (!client.isEnabled()) {
       if (peer.preferEncrypted) {
-        toggle.visible = true
-        toggle.checked = false
-        toggle.enabled = true
         toggle.explanation = 'enable Autocrypt to encrypt'
       }
       else {
         toggle.visible = false
-        toggle.checked = false
         toggle.enabled = false
-        toggle.explanation = ''
       }
     }
     else {
-      toggle.visible = true
       dom.encryptedRow.style.display = 'table-row'
       if (peer.key) {
-        toggle.checked = dom.encrypted.checked || peer.preferEncrypted
-        toggle.enabled = true
-        toggle.explanation = ''
+        toggle.preferred = peer.preferEncrypted
       }
       else {
-        toggle.checked = false
         toggle.enabled = false
         if (to === '') {
           toggle.explanation = 'please choose a recipient'
@@ -61,7 +57,8 @@
     }
     dom.encryptedRow.style.display = toggle.visible ? 'table-row' : 'none'
     enableCheckbox(toggle.enabled)
-    dom.encrypted.checked = toggle.checked
+    // On replies this may already be checked. So do not uncheck.
+    dom.encrypted.checked = dom.encrypted.checked || toggle.preferred
     dom.explanation.innerText = toggle.explanation
 
   }

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -2,30 +2,6 @@
   var dom;
   var pane;
 
-  // run when the dom is loaded
-  function setup (event) {
-    pane = document.getElementById('compose')
-    dom = getElements(
-      'to', 'subject', 'body', 'encrypted', 'encryptedRow', 'explanation',
-      'send'
-      )
-    if (pane) {
-      pane.addEventListener('clear', clear, false)
-      pane.addEventListener('update', update, false)
-      pane.addEventListener('reply', reply, false)
-    }
-
-    dom.send.addEventListener('click', function (){
-      var send = new CustomEvent('send', { detail: {
-        to: dom.to.value,
-        subject: dom.subject.value,
-        body: dom.body.value,
-        encrypted: dom.encrypted.checked
-      }})
-      pane.dispatchEvent(send)
-    }, false)
-  }
-
   function clear (e) {
     dom.to.value = ''
     dom.body.value = ''
@@ -37,6 +13,10 @@
     var client = e.detail.client
     var to = dom.to.value
     var ac = client.getPeerAc(to)
+    function enablecheckbox (box, enabled) {
+      box.disabled = !enabled
+        if (enabled) { box.parentElement.classList.remove('disabled') } else { box.parentElement.classList.add('disabled') }
+    }
 
     if (!client.isEnabled()) {
       if (ac.preferEncrypted) {
@@ -75,6 +55,16 @@
     dom.encrypted.checked = dom.encrypted.checked || msg.encrypted
   }
 
+  function send (){
+    var sendEvent = new CustomEvent('send', { detail: {
+      to: dom.to.value,
+      subject: dom.subject.value,
+      body: dom.body.value,
+      encrypted: dom.encrypted.checked
+    }})
+    pane.dispatchEvent(sendEvent)
+  }
+
   function getElements() {
     collection = {}
     for (id of arguments) {
@@ -83,9 +73,20 @@
     return collection
   }
 
-  function enablecheckbox (box, enabled) {
-    box.disabled = !enabled
-    if (enabled) { box.parentElement.classList.remove('disabled') } else { box.parentElement.classList.add('disabled') }
+  // run when the dom is loaded
+  function setup (event) {
+    pane = document.getElementById('compose')
+    dom = getElements(
+      'to', 'subject', 'body', 'encrypted', 'encryptedRow', 'explanation',
+      'send'
+      )
+    if (pane) {
+      pane.addEventListener('clear', clear, false)
+      pane.addEventListener('update', update, false)
+      pane.addEventListener('reply', reply, false)
+    }
+
+    dom.send.addEventListener('click', send, false)
   }
 
   document.addEventListener("DOMContentLoaded", setup)

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -13,34 +13,57 @@
     var to = dom.to.value
     var client = e.detail.client
     var peer = e.detail.peer
+    var toggle = {}
 
-    function enablecheckbox (box, enabled) {
+    function enableCheckbox (enabled) {
+      var box = dom.encrypted
       box.disabled = !enabled
-        if (enabled) { box.parentElement.classList.remove('disabled') } else { box.parentElement.classList.add('disabled') }
+      if (enabled) {
+        box.parentElement.classList.remove('disabled')
+      } else {
+        box.parentElement.classList.add('disabled')
+      }
     }
 
     if (!client.isEnabled()) {
       if (peer.preferEncrypted) {
-        dom.encryptedRow.style.display = 'table-row'
-        dom.encrypted.checked = false
-        enablecheckbox(dom.encrypted, true)
-        dom.explanation.innerText = 'enable Autocrypt to encrypt'
-      } else {
-        dom.encryptedRow.style.display = 'none'
-        dom.encrypted.checked = false
+        toggle.visible = true
+        toggle.checked = false
+        toggle.enabled = true
+        toggle.explanation = 'enable Autocrypt to encrypt'
       }
-    } else {
-      dom.encryptedRow.style.display = 'table-row'
-      if (peer.key !== undefined) {
-        dom.encrypted.checked = dom.encrypted.checked || peer.preferEncrypted
-        enablecheckbox(dom.encrypted, true)
-        dom.explanation.innerText = ''
-      } else {
-        dom.encrypted.checked = false
-        enablecheckbox(dom.encrypted, false)
-        if (to === '') { dom.explanation.innerText = 'please choose a recipient' } else { dom.explanation.innerText = 'If you want to encrypt to ' + to + ', ask ' + to + ' to enable Autocrypt and send you an e-mail' }
+      else {
+        toggle.visible = false
+        toggle.checked = false
+        toggle.enabled = false
+        toggle.explanation = ''
       }
     }
+    else {
+      toggle.visible = true
+      dom.encryptedRow.style.display = 'table-row'
+      if (peer.key) {
+        toggle.checked = dom.encrypted.checked || peer.preferEncrypted
+        toggle.enabled = true
+        toggle.explanation = ''
+      }
+      else {
+        toggle.checked = false
+        toggle.enabled = false
+        if (to === '') {
+          toggle.explanation = 'please choose a recipient'
+        }
+        else {
+          toggle.explanation = 'If you want to encrypt to ' + to +
+            ', ask ' + to + ' to enable Autocrypt and send you an e-mail'
+        }
+      }
+    }
+    dom.encryptedRow.style.display = toggle.visible ? 'table-row' : 'none'
+    enableCheckbox(toggle.enabled)
+    dom.encrypted.checked = toggle.checked
+    dom.explanation.innerText = toggle.explanation
+
   }
 
   function reply(e){

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -85,6 +85,10 @@
 
     dom.send.addEventListener('click', send, false)
     dom.to.addEventListener('change', toChanged, false)
+
+    var lock = document.createElement('img')
+    lock.src = 'assets/images/emblem-readonly.png'
+    dom.encrypted.parentNode.insertBefore(lock, dom.encrypted)
   }
 
   document.addEventListener("DOMContentLoaded", setup)

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -1,0 +1,67 @@
+(function () {
+  var dom;
+  var pane;
+
+  // run when the dom is loaded
+  function setup (event) {
+    pane = document.getElementById('compose')
+    dom = getElements(
+      'to', 'subject', 'body', 'encrypted', 'encryptedRow', 'explanation'
+      )
+    if (pane) {
+      pane.addEventListener('clear', clear, false)
+      pane.addEventListener('update', update, false)
+    }
+  }
+
+  function clear (e) {
+    dom.to.value = ''
+    dom.body.value = ''
+    dom.subject.value = ''
+    dom.encrypted.checked = false
+  }
+
+  function update (e) {
+    var client = e.detail.client
+    var to = dom.to.value
+    var ac = client.getPeerAc(to)
+
+    if (!client.isEnabled()) {
+      if (ac.preferEncrypted) {
+        dom.encryptedRow.style.display = 'table-row'
+        dom.encrypted.checked = false
+        enablecheckbox(dom.encrypted, true)
+        dom.explanation.innerText = 'enable Autocrypt to encrypt'
+      } else {
+        dom.encryptedRow.style.display = 'none'
+      }
+    } else {
+      dom.encryptedRow.style.display = 'table-row'
+      if (ac.key !== undefined) {
+        dom.encrypted.checked = ac.preferEncrypted
+        enablecheckbox(dom.encrypted, true)
+        dom.explanation.innerText = ''
+      } else {
+        dom.encrypted.checked = false
+        enablecheckbox(dom.encrypted, false)
+        if (to === '') { dom.explanation.innerText = 'please choose a recipient' } else { dom.explanation.innerText = 'If you want to encrypt to ' + to + ', ask ' + to + ' to enable Autocrypt and send you an e-mail' }
+      }
+    }
+  }
+
+  function getElements() {
+    collection = {}
+    for (id of arguments) {
+      collection[id] = document.getElementById(id)
+    }
+    return collection
+  }
+
+  function enablecheckbox (box, enabled) {
+    box.disabled = !enabled
+    if (enabled) { box.parentElement.classList.remove('disabled') } else { box.parentElement.classList.add('disabled') }
+  }
+
+  document.addEventListener("DOMContentLoaded", setup)
+
+})()

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -10,15 +10,7 @@
   }
 
   function update (e) {
-    var to = dom.to.value
-    var client = e.detail.client
-    var peer = e.detail.peer
-    var toggle = {
-      visible: true,
-      enabled: true,
-      preferred: false,
-      explanation: ''
-    }
+    var toggle = e.detail.toggle
 
     function enableCheckbox (enabled) {
       var box = dom.encrypted
@@ -30,31 +22,6 @@
       }
     }
 
-    if (!client.isEnabled()) {
-      if (peer.preferEncrypted) {
-        toggle.explanation = 'enable Autocrypt to encrypt'
-      }
-      else {
-        toggle.visible = false
-        toggle.enabled = false
-      }
-    }
-    else {
-      dom.encryptedRow.style.display = 'table-row'
-      if (peer.key) {
-        toggle.preferred = peer.preferEncrypted
-      }
-      else {
-        toggle.enabled = false
-        if (to === '') {
-          toggle.explanation = 'please choose a recipient'
-        }
-        else {
-          toggle.explanation = 'If you want to encrypt to ' + to +
-            ', ask ' + to + ' to enable Autocrypt and send you an e-mail'
-        }
-      }
-    }
     dom.encryptedRow.style.display = toggle.visible ? 'table-row' : 'none'
     enableCheckbox(toggle.enabled)
     // On replies this may already be checked. So do not uncheck.

--- a/ui/compose.js
+++ b/ui/compose.js
@@ -6,13 +6,24 @@
   function setup (event) {
     pane = document.getElementById('compose')
     dom = getElements(
-      'to', 'subject', 'body', 'encrypted', 'encryptedRow', 'explanation'
+      'to', 'subject', 'body', 'encrypted', 'encryptedRow', 'explanation',
+      'send'
       )
     if (pane) {
       pane.addEventListener('clear', clear, false)
       pane.addEventListener('update', update, false)
       pane.addEventListener('reply', reply, false)
     }
+
+    dom.send.addEventListener('click', function (){
+      var send = new CustomEvent('send', { detail: {
+        to: dom.to.value,
+        subject: dom.subject.value,
+        body: dom.body.value,
+        encrypted: dom.encrypted.checked
+      }})
+      pane.dispatchEvent(send)
+    }, false)
   }
 
   function clear (e) {

--- a/ui/list.js
+++ b/ui/list.js
@@ -1,0 +1,112 @@
+(function () {
+  var dom;
+  var pane;
+
+  function populate (e) {
+    var messages = e.detail.messages
+    clear()
+    appendMessages(messages)
+    if (messages.length) {
+      showMessages()
+    }
+    else {
+      showMessageReplacement()
+    }
+  }
+
+  function clear () {
+    while (dom.msglist.hasChildNodes()) {
+      dom.msglist.removeChild(dom.msglist.lastChild)
+    }
+  }
+
+  function appendMessages () {
+    for (let message of messages) {
+      dom.msglist.appendChild(generateListEntryFromMsg(message))
+    }
+  }
+
+  function generateListEntryFromMsg (msg) {
+    var ret = document.createElement('tr')
+    ret.classList.add('message')
+    ret.onclick = function () {
+      emit('showMessage', { message: msg })
+    }
+
+    var e = document.createElement('td')
+    if (msg['encrypted']) { e.appendChild(img('lock')) }
+    if (msg['to'].toLowerCase() === dom.username.innerText.toLowerCase()) {
+      e.appendChild(img('back'))
+    }
+    if (msg['from'].toLowerCase() === dom.username.innerText.toLowerCase()) {
+      e.appendChild(img('forward'))
+    }
+    ret.appendChild(e)
+
+    var f = document.createElement('td')
+    f.innerText = msg['from']
+    ret.appendChild(f)
+
+    var t = document.createElement('td')
+    t.innerText = msg['to']
+    ret.appendChild(t)
+
+    var s = document.createElement('td')
+    s.innerText = msg['subject']
+    ret.appendChild(s)
+
+    var d = document.createElement('td')
+    d.innerText = msg['date']
+    ret.appendChild(d)
+
+    return ret
+  }
+
+  function showMessages () {
+    dom.listReplacement.style.display = 'none'
+    dom.msgtable.style.display = 'table'
+  }
+
+  function showMessageReplacement() {
+    dom.listReplacement.style.display = 'block'
+    dom.msgtable.style.display = 'none'
+  }
+
+  function img (what) {
+    var index = {
+      lock: 'assets/images/emblem-readonly.png',
+      back: 'assets/images/back.png',
+      forward: 'assets/images/forward.png'
+    }
+    var lock = document.createElement('img')
+    lock.src = index[what]
+    return lock
+  }
+
+  function emit(name, detail){
+    var emitEvent = new CustomEvent(name, { detail: detail } )
+    pane.dispatchEvent(emitEvent)
+  }
+
+  function getElements() {
+    collection = {}
+    for (id of arguments) {
+      collection[id] = document.getElementById(id)
+    }
+    return collection
+  }
+
+  // run when the dom is loaded
+  function setup (event) {
+    pane = document.getElementById('list')
+    dom = getElements(
+      'listReplacement', 'msgtable', 'msglist', 'username'
+      )
+    if (pane) {
+      pane.addEventListener('populate', populate, false)
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", setup)
+
+})()

--- a/ui/panes.js
+++ b/ui/panes.js
@@ -43,11 +43,11 @@
         }
     }
     panes[choice].style.display = 'block'
+    panes[choice].dispatchEvent(selected)
     var n = 'tab-' + choice
     e = document.getElementById(n)
     if (e) {
       e.classList.add('selected')
-      e.dispatchEvent(selected)
     }
   }
 

--- a/ui/panes.js
+++ b/ui/panes.js
@@ -12,7 +12,7 @@
 
   // run when the dom is loaded
   function setup (event) {
-    panes = getElements('compose', 'list', 'msgView', 'preferences')
+    panes = getElements('compose', 'list', 'view', 'preferences')
 
     function assignListener(id) {
       var link = document.getElementById('tab-'+id)

--- a/ui/panes.js
+++ b/ui/panes.js
@@ -1,4 +1,4 @@
-function uiPanes () {
+(function () {
   var panes = {}
 
   function getElements() {
@@ -16,13 +16,20 @@ function uiPanes () {
 
     function assignListener(id) {
       var link = document.getElementById('tab-'+id)
+      var pane = document.getElementById(id)
+      function activate() {
+        return select(id)
+      }
       if (link) {
-        link.addEventListener('click', function() {
-          return select(id)
-        }, false)
+        link.addEventListener('click', activate, false)
+      }
+      if (pane) {
+        pane.addEventListener('select', activate, false)
       }
     }
     Object.keys(panes).forEach(assignListener)
+
+    select('list')
   }
 
   var selected = new Event("selected")
@@ -44,9 +51,6 @@ function uiPanes () {
     }
   }
 
-  return {
-    setup: setup,
-    select: select
-  }
+  document.addEventListener("DOMContentLoaded", setup)
 
-}
+})()

--- a/ui/view.js
+++ b/ui/view.js
@@ -1,0 +1,63 @@
+(function () {
+  var dom;
+  var pane;
+
+  // run when the dom is loaded
+  function setup (event) {
+    pane = document.getElementById('view')
+    dom = getViewElements(
+      'From', 'To', 'Subject', 'Date',
+      'Body', 'Encrypted')
+    dom.reply = document.getElementById('reply')
+
+    if (pane) {
+      pane.addEventListener('show', show, false)
+    }
+  }
+
+  function show(e) {
+    var msg = e.detail.message
+    dom.from.innerText = msg.from
+    dom.to.innerText = msg.to
+    dom.subject.innerText = msg.subject
+    dom.date.innerText = msg.date
+    dom.body.innerText = msg.body
+    dom.encrypted.replaceChild(getEncryptionStatusNode(msg.encrypted), dom.encrypted.childNodes[0])
+    // fix before refactor
+    var usr = us.current()
+    if (msg.from === usr.name) {
+      dom.reply.style.display = 'none'
+    } else {
+      dom.reply.style.display = 'inline'
+    }
+  }
+
+  function getEncryptionStatusNode (encrypted) {
+    var x = document.createElement('span')
+      if (encrypted) {
+        let sub = document.createElement('span')
+        let lock = document.createElement('img')
+        lock.src = 'assets/images/emblem-readonly.png'
+        x.appendChild(lock)
+        sub.innerText = 'Message was encrypted'
+        x.appendChild(sub)
+      } else {
+        x.innerText = 'Message was not encrypted'
+      }
+
+    return x
+  }
+
+  function getViewElements() {
+    collection = {}
+    for (id of arguments) {
+      let key = id.toLowerCase()
+        let domId = 'view'+id
+        collection[key] = document.getElementById(domId)
+    }
+    return collection
+  }
+
+  document.addEventListener("DOMContentLoaded", setup)
+
+})()

--- a/ui/view.js
+++ b/ui/view.js
@@ -25,11 +25,19 @@
     dom.encrypted.replaceChild(getEncryptionStatusNode(msg.encrypted), dom.encrypted.childNodes[0])
     // fix before refactor
     var usr = us.current()
+    dom.reply.onclick = function () { replyToMsg(msg) }
     if (msg.from === usr.name) {
       dom.reply.style.display = 'none'
     } else {
       dom.reply.style.display = 'inline'
     }
+  }
+
+  function replyToMsg (msg) {
+    var reply = new CustomEvent('reply', {
+      detail: {message: msg}
+    })
+    pane.dispatchEvent(reply)
   }
 
   function getEncryptionStatusNode (encrypted) {


### PR DESCRIPTION
Separating out the different panes into their own views that communicate via events on dom objects rather than globals.